### PR TITLE
Fix NIP-57 zap receipts

### DIFF
--- a/src/services/lnd/addInvoiceReq.ts
+++ b/src/services/lnd/addInvoiceReq.ts
@@ -1,14 +1,14 @@
 import { OpenChannelRequest, Invoice } from "../../../proto/lnd/lightning";
 
-export const AddInvoiceReq = (value: number, expiry = 60 * 60, privateHints = false, memo?: string, blind = false): Invoice => ({
+export const AddInvoiceReq = (value: number, expiry = 60 * 60, privateHints = false, memo?: string, blind = false, descriptionHash?: Buffer): Invoice => ({
     expiry: BigInt(expiry),
-    memo: memo || "",
+    memo: descriptionHash ? "" : memo || "",
     private: blind ? false : privateHints,
     value: BigInt(value),
 
     fallbackAddr: "",
     cltvExpiry: 0n,
-    descriptionHash: Buffer.alloc(0),
+    descriptionHash: descriptionHash || Buffer.alloc(0),
     features: {},
     isAmp: false,
     rPreimage: Buffer.alloc(0),

--- a/src/services/lnd/lnd.ts
+++ b/src/services/lnd/lnd.ts
@@ -396,18 +396,19 @@ export default class {
         }
     }
 
-    async NewInvoice(value: number, memo: string, expiry: number, { useProvider, from }: TxActionOptions, blind = false): Promise<Invoice> {
+    async NewInvoice(value: number, memo: string, expiry: number, { useProvider, from }: TxActionOptions, blind = false, zapDescription?: string): Promise<Invoice> {
         this.log(DEBUG, "Creating new invoice")
         // Force use of provider when bypass is enabled
         const mustUseProvider = this.liquidProvider.getSettings().useOnlyLiquidityProvider || useProvider
         if (mustUseProvider) {
             this.log(INFO, "using provider")
-            const invoice = await this.liquidProvider.AddInvoice(value, memo, from, expiry)
+            const invoice = await this.liquidProvider.AddInvoice(value, memo, from, expiry, zapDescription)
             const providerPubkey = this.liquidProvider.GetProviderPubkey()
             return { payRequest: invoice, providerPubkey }
         }
         try {
-            const res = await this.lightning.addInvoice(AddInvoiceReq(value, expiry, true, memo, blind), DeadLineMetadata())
+            const descriptionHash = zapDescription ? crypto.createHash('sha256').update(zapDescription).digest() : undefined
+            const res = await this.lightning.addInvoice(AddInvoiceReq(value, expiry, true, memo, blind, descriptionHash), DeadLineMetadata())
             this.utils.stateBundler.AddTxPoint('addedInvoice', value, { from, used: 'lnd' })
             return { payRequest: res.response.paymentRequest }
         } catch (err) {

--- a/src/services/main/index.ts
+++ b/src/services/main/index.ts
@@ -294,7 +294,7 @@ export default class {
                 const op = { amount, paidAtUnix: Date.now() / 1000, inbound: true, type: Types.UserOperationType.INCOMING_INVOICE, identifier: userInvoice.invoice, operationId, network_fee: 0, service_fee: fee, confirmed: true, tx_hash: "", internal }
                 this.sendOperationToNostr(userInvoice.linkedApplication, userInvoice.user.user_id, op)
                 try {
-                    this.createZapReceipt(log, userInvoice)
+                    await this.createZapReceipt(log, userInvoice)
                 } catch (err: any) {
                     log(ERROR, "cannot create zap receipt", err.message || "")
                 }
@@ -487,10 +487,20 @@ export default class {
         if (!zapInfo || !invoice.linkedApplication || !invoice.linkedApplication.nostr_public_key) {
             return
         }
-        const tags = [["p", zapInfo.pub], ["bolt11", invoice.invoice], ["description", zapInfo.description]]
+        const tags = [["p", zapInfo.pub]]
+        if (zapInfo.senderPub) {
+            tags.push(["P", zapInfo.senderPub])
+        }
         if (zapInfo.eventId) {
             tags.push(["e", zapInfo.eventId])
         }
+        if (zapInfo.eventCoordinate) {
+            tags.push(["a", zapInfo.eventCoordinate])
+        }
+        if (zapInfo.eventKind) {
+            tags.push(["k", zapInfo.eventKind])
+        }
+        tags.push(["bolt11", invoice.invoice], ["description", zapInfo.description])
         const event: UnsignedEvent = {
             content: "",
             created_at: invoice.paid_at_unix,

--- a/src/services/main/liquidityProvider.ts
+++ b/src/services/main/liquidityProvider.ts
@@ -206,12 +206,12 @@ export class LiquidityProvider {
         return true
     }
 
-    AddInvoice = async (amount: number, memo: string, from: 'user' | 'system', expiry: number) => {
+    AddInvoice = async (amount: number, memo: string, from: 'user' | 'system', expiry: number, zap?: string) => {
         try {
             if (!this.IsReady()) {
                 throw new Error("liquidity provider is not ready yet, disabled or unreachable")
             }
-            const res = await this.client.NewInvoice({ amountSats: amount, memo, expiry })
+            const res = await this.client.NewInvoice({ amountSats: amount, memo, expiry, zap })
             if (res.status === 'ERROR') {
                 this.log("error creating invoice", res.reason)
                 throw new Error(res.reason)

--- a/src/services/main/paymentManager.ts
+++ b/src/services/main/paymentManager.ts
@@ -385,7 +385,7 @@ export default class {
             throw new Error("user is banned, cannot generate invoice")
         }
         const use = await this.liquidityManager.beforeInvoiceCreation(req.amountSats)
-        const res = await this.lnd.NewInvoice(req.amountSats, req.memo, options.expiry, { useProvider: use === 'provider', from: 'user' }, req.blind)
+        const res = await this.lnd.NewInvoice(req.amountSats, req.memo, options.expiry, { useProvider: use === 'provider', from: 'user' }, req.blind, options.zapInfo?.description)
         const userInvoice = await this.storage.paymentStorage.AddUserInvoice(user, res.payRequest, options, res.providerPubkey)
         const appId = options.linkedApplication ? options.linkedApplication.app_id : ""
         this.storage.eventsLog.LogEvent({ type: 'new_invoice', userId: user.user_id, appUserId: "", appId, balance: user.balance_sats, data: userInvoice.invoice, amount: req.amountSats })
@@ -786,12 +786,22 @@ export default class {
         }
         const p = this.parseTags("p", nostrEvent.tags, { required: true })
         const e = this.parseTags("e", nostrEvent.tags)
+        const a = this.parseTags("a", nostrEvent.tags)
+        const k = this.parseTags("k", nostrEvent.tags)
         const relays = this.parseTags("relays", nostrEvent.tags, { required: true, multiples: true })
         const amount = this.parseTags("amount", nostrEvent.tags)
         if (amount.length > 0 && +amount[0] !== amt) {
             throw new Error("amount mismatch")
         }
-        return { pub: p[0], eventId: e.length > 0 ? e[0] : "", relays, description: event }
+        return {
+            pub: p[0],
+            eventId: e.length > 0 ? e[0] : "",
+            relays,
+            description: event,
+            senderPub: nostrEvent.pubkey,
+            eventCoordinate: a.length > 0 ? a[0] : "",
+            eventKind: k.length > 0 ? k[0] : "",
+        }
     }
 
     async HandleLnurlPay(ctx: Types.HandleLnurlPay_Query): Promise<Types.HandleLnurlPayResponse> {

--- a/src/services/storage/entity/UserReceivingInvoice.ts
+++ b/src/services/storage/entity/UserReceivingInvoice.ts
@@ -7,6 +7,9 @@ export type ZapInfo = {
     eventId: string
     relays: string[]
     description: string
+    senderPub?: string
+    eventCoordinate?: string
+    eventKind?: string
 }
 @Entity()
 @Index("recv_invoice_paid_serial", ["user.serial_id", "paid_at_unix", "serial_id"], { where: "paid_at_unix > 0" })


### PR DESCRIPTION
## Summary
- Generate zap invoices with a NIP-57 description hash so the bolt11 commits to the zap request.
- Preserve zap sender and target metadata for kind 9735 receipts, and await receipt publishing so failures are logged.
- Forward zap payloads through provider-backed invoice creation.

## Test plan
- [x] `npx tsc --noEmit`


Made with [Cursor](https://cursor.com)