### PR TITLE
Rewrite Umbrel package for current Pub + wizard UI

### DIFF
--- a/Umbrel/README.md
+++ b/Umbrel/README.md
@@ -1,26 +1,24 @@
-# Umbrel packaging (reference)
+# Umbrel packaging
 
-Modern Umbrel App Store reference package for Lightning.Pub.
+Reference files for packaging Lightning.Pub as an Umbrel app.
 
-The previous `Umbrel/` files targeted a dead image tag (`lightning.pub:umbrel-works`)
-and Umbrel conventions from ~2024. This rewrite is meant to be copied into
-[`getumbrel/umbrel-apps`](https://github.com/getumbrel/umbrel-apps) as `lightning-pub/`
-once validated on a real Umbrel (LND dependency + wizard UI).
+Copy this directory into [`getumbrel/umbrel-apps`](https://github.com/getumbrel/umbrel-apps) as `lightning-pub/` after it has been tested on Umbrel with the Lightning Node app installed and unlocked.
 
-## Runtime shape
+## How it runs on Umbrel
 
 | Piece | Value |
 | --- | --- |
-| Image | `ghcr.io/shocknet/lightning-pub:0.0.40` (multi-arch amd64/arm64) |
-| LND | Umbrel `lightning` app via `${APP_LIGHTNING_NODE_*}` + macaroon/cert mount |
-| API | `PORT=1776` |
-| Wizard UI | `WIZARD=true`, listens on `PORT+1` → **1777** (proxied by Umbrel `app_proxy`) |
-| Data | `${APP_DATA_DIR}/data` → `/data` (`DATA_DIR`, sqlite DBs) |
+| Image | `ghcr.io/shocknet/lightning-pub:0.0.40` (linux/amd64 and linux/arm64) |
+| Lightning backend | Umbrel Lightning Node (LND), via mounted cert/macaroon and gRPC address |
+| HTTP API | port `1776` inside the container |
+| Browser UI | wizard on port `1777` (`PORT + 1`), exposed through Umbrel `app_proxy` |
+| Persistent data | host `${APP_DATA_DIR}/data` mounted at `/data` |
 
-## Known follow-ups before App Store merge
+## Before submitting to the Umbrel App Store
 
-1. **Prebuild the Docker image** so the container does not `tsc` on every start, then run as `user: "1000:1000"`.
-2. Sideload/test on Umbrel OS 1.x with Lightning Node unlocked; confirm wizard + ShockWallet admin connect.
-3. Pick a final store `port` (currently `40176`) and fill `submission` with the umbrel-apps PR URL.
-4. Optional: whitelist narrow HTTP paths if companion clients must hit Pub without Umbrel auth cookies.
-5. Optional LNURL/`SERVICE_URL` docs for operators with a public domain.
+1. Change the Docker image so TypeScript is compiled at build time, not on every container start. Then run the container as `user: "1000:1000"`.
+2. Install this package on Umbrel, open the wizard, and confirm ShockWallet can connect with the admin string.
+3. Confirm Pub data is still present after a container restart.
+4. Set the final App Store `port` if `40176` needs to change, and put the umbrel-apps PR URL in `submission`.
+5. If external clients must call Pub HTTP without Umbrel login cookies, add a narrow `PROXY_AUTH_WHITELIST`.
+6. Document optional LNURL / `SERVICE_URL` setup for operators who have a public HTTPS domain.

--- a/Umbrel/README.md
+++ b/Umbrel/README.md
@@ -1,0 +1,26 @@
+# Umbrel packaging (reference)
+
+Modern Umbrel App Store reference package for Lightning.Pub.
+
+The previous `Umbrel/` files targeted a dead image tag (`lightning.pub:umbrel-works`)
+and Umbrel conventions from ~2024. This rewrite is meant to be copied into
+[`getumbrel/umbrel-apps`](https://github.com/getumbrel/umbrel-apps) as `lightning-pub/`
+once validated on a real Umbrel (LND dependency + wizard UI).
+
+## Runtime shape
+
+| Piece | Value |
+| --- | --- |
+| Image | `ghcr.io/shocknet/lightning-pub:0.0.40` (multi-arch amd64/arm64) |
+| LND | Umbrel `lightning` app via `${APP_LIGHTNING_NODE_*}` + macaroon/cert mount |
+| API | `PORT=1776` |
+| Wizard UI | `WIZARD=true`, listens on `PORT+1` → **1777** (proxied by Umbrel `app_proxy`) |
+| Data | `${APP_DATA_DIR}/data` → `/data` (`DATA_DIR`, sqlite DBs) |
+
+## Known follow-ups before App Store merge
+
+1. **Prebuild the Docker image** so the container does not `tsc` on every start, then run as `user: "1000:1000"`.
+2. Sideload/test on Umbrel OS 1.x with Lightning Node unlocked; confirm wizard + ShockWallet admin connect.
+3. Pick a final store `port` (currently `40176`) and fill `submission` with the umbrel-apps PR URL.
+4. Optional: whitelist narrow HTTP paths if companion clients must hit Pub without Umbrel auth cookies.
+5. Optional LNURL/`SERVICE_URL` docs for operators with a public domain.

--- a/Umbrel/docker-compose.yml
+++ b/Umbrel/docker-compose.yml
@@ -1,22 +1,33 @@
 version: "3.7"
+
 services:
   app_proxy:
     environment:
-      APP_HOST: lightning-pub
-      APP_PORT: 1776
-      
-  server:
-    image: ghcr.io/shocknet/lightning.pub:umbrel-works
-    volumes:
-      - "${APP_DATA_DIR}/data:/data"
-      - "${APP_LIGHTNING_NODE_DATA_DIR}:/lnd:ro"
-    environment:
-      LN_BACKEND_TYPE: "LND"
-      LND_ADDRESS: $APP_LIGHTNING_NODE_IP:$APP_LIGHTNING_NODE_GRPC_PORT
-      LND_CERT_PATH: "/lnd/tls.cert"
-      LND_MACAROON_PATH: "/lnd/data/chain/bitcoin/${APP_BITCOIN_NETWORK}/admin.macaroon"
-      DATABASE_FILE: "/data/db.sqlite"
-      METRICS_DATABASE_FILE: "/data/metrics.sqlite"
-      PORT: 1776
+      # Umbrel injects container name as <app-id>_<service>_1
+      APP_HOST: lightning-pub_web_1
+      # Wizard UI listens on PORT+1 (see src/services/wizard/index.ts)
+      APP_PORT: 1777
+
+  web:
+    image: ghcr.io/shocknet/lightning-pub:0.0.40@sha256:adfd284a7c49f78df3d5dedf97ce8c292e83203732dd5bdd9de6ffca17d7713e
+    # Upstream image currently builds TypeScript on start and expects write access under /app,
+    # so it must run as the image default (root). Follow-up: ship a prebuilt image and run as 1000:1000.
     restart: on-failure
     stop_grace_period: 1m
+    volumes:
+      - ${APP_DATA_DIR}/data:/data
+      - ${APP_LIGHTNING_NODE_DATA_DIR}:/lnd:ro
+    environment:
+      DATA_DIR: /data
+      DATABASE_FILE: /data/db.sqlite
+      METRICS_DATABASE_FILE: /data/metrics.sqlite
+      PORT: "1776"
+      WIZARD: "true"
+      BTC_NETWORK: ${APP_BITCOIN_NETWORK}
+      LND_ADDRESS: ${APP_LIGHTNING_NODE_IP}:${APP_LIGHTNING_NODE_GRPC_PORT}
+      LND_CERT_PATH: /lnd/tls.cert
+      LND_MACAROON_PATH: /lnd/data/chain/bitcoin/${APP_BITCOIN_NETWORK}/admin.macaroon
+      LND_LOG_DIR: /lnd/logs/bitcoin/${APP_BITCOIN_NETWORK}/lnd.log
+      JWT_SECRET: ${APP_SEED}
+      # Shared Umbrel LND is also used by other apps; give the watchdog headroom.
+      WATCHDOG_MAX_DIFF_SATS: "100000000"

--- a/Umbrel/docker-compose.yml
+++ b/Umbrel/docker-compose.yml
@@ -10,8 +10,9 @@ services:
 
   web:
     image: ghcr.io/shocknet/lightning-pub:0.0.40@sha256:adfd284a7c49f78df3d5dedf97ce8c292e83203732dd5bdd9de6ffca17d7713e
-    # Upstream image currently builds TypeScript on start and expects write access under /app,
-    # so it must run as the image default (root). Follow-up: ship a prebuilt image and run as 1000:1000.
+    # This image compiles TypeScript on start and needs write access under /app,
+    # so it runs as the image default user (root). Next step: prebuild the image
+    # and run as user 1000:1000.
     restart: on-failure
     stop_grace_period: 1m
     volumes:
@@ -29,5 +30,7 @@ services:
       LND_MACAROON_PATH: /lnd/data/chain/bitcoin/${APP_BITCOIN_NETWORK}/admin.macaroon
       LND_LOG_DIR: /lnd/logs/bitcoin/${APP_BITCOIN_NETWORK}/lnd.log
       JWT_SECRET: ${APP_SEED}
-      # Shared Umbrel LND is also used by other apps; give the watchdog headroom.
+      # Default watchdog limit is 0 sats. Other Umbrel apps can spend from the same
+      # LND, so allow up to 100,000,000 sats (1 BTC) of balance difference before
+      # Pub blocks outbound payments.
       WATCHDOG_MAX_DIFF_SATS: "100000000"

--- a/Umbrel/umbrel-app.yml
+++ b/Umbrel/umbrel-app.yml
@@ -1,36 +1,45 @@
 manifestVersion: 1
 id: lightning-pub
-category: finance
+category: bitcoin
 name: Lightning.Pub
-version: "1.0.0"
-tagline: lightning, nostr, accounts, lnurl, web
+version: "0.0.40"
+tagline: Nostr-native Lightning accounts for friends, family, and apps
 description: >-
-  "Pub" is a Nostr-native account system designed 
-  to make running Lightning infrastructure for your friends/family/customers 
-  easier than previously thought possible.
+  Lightning.Pub ("Pub") turns your Umbrel Lightning Node into a Nostr-native
+  account system you can share with guests and apps — without port forwarding,
+  Tor gymnastics, or LNURL reverse proxies.
 
-  Being Nostr-native eliminates the complexity of configuring your node like a server by using commodity Nostr relays. 
-  These relays, unlike LNURL proxies, are trustless by nature of Nostr's own encryption spec (NIP44).
 
-  Support for optional services are integrated into Pub for operators seeking backward compatibility with legacy LNURLs and Lightning Addresses.
+  SET-UP
 
-  By solving the networking and programability hurdles, Pub provides Lightning with a 3rd Layer that enables node-runners and 
-  Uncle Jims to more easily bring their personal network into Bitcoin's permissionless economy. In doing so, Pub runners 
-  can keep the Lightning Network decentralized, with custodial scaling that is free of fiat rails, large banks, 
-  and other forms of high-time-preference shitcoinery.
+
+  1. Install and unlock the Lightning Node app first (LND).
+
+
+  2. Open Lightning.Pub and complete the on-device wizard (source name, relay).
+
+
+  3. Scan or copy the admin connection string into ShockWallet to manage the Pub.
+
+
+  Guests and apps connect over encrypted Nostr (NIP-44). Optional LNURL / Lightning
+  Address support needs a public HTTPS domain pointed at Pub (advanced).
+
+
+  This Pub shares your Umbrel LND. Other Lightning apps on the same node remain
+  supported; the watchdog allowance is raised for shared use.
+
+releaseNotes: ""
 developer: shocknet
-website: https://shock.network
+website: https://lightning.pub
 dependencies:
   - lightning
 repo: https://github.com/shocknet/Lightning.Pub
 support: https://github.com/shocknet/Lightning.Pub/discussions
-port: 1776
-gallery:
-  - 1.jpg
-  - 2.jpg
-  - 3.jpg
+port: 40176
+gallery: []
 path: ""
 defaultUsername: ""
 defaultPassword: ""
 submitter: shocknet
-submission: https://github.com/getumbrel/umbrel/pull/334
+submission: ""

--- a/Umbrel/umbrel-app.yml
+++ b/Umbrel/umbrel-app.yml
@@ -7,7 +7,7 @@ tagline: Nostr-native Lightning accounts for friends, family, and apps
 description: >-
   Lightning.Pub ("Pub") turns your Umbrel Lightning Node into a Nostr-native
   account system you can share with guests and apps — without port forwarding,
-  Tor gymnastics, or LNURL reverse proxies.
+  Tor setup, or LNURL reverse proxies.
 
 
   SET-UP
@@ -26,8 +26,10 @@ description: >-
   Address support needs a public HTTPS domain pointed at Pub (advanced).
 
 
-  This Pub shares your Umbrel LND. Other Lightning apps on the same node remain
-  supported; the watchdog allowance is raised for shared use.
+  Pub uses the same LND as your other Umbrel Lightning apps. Pub's balance watchdog
+  normally blocks sends if LND's balance differs from Pub's internal books by more
+  than 0 sats. On Umbrel that difference is expected when other apps also spend from
+  LND, so this package sets the allowed difference to 100,000,000 sats (1 BTC).
 
 releaseNotes: ""
 developer: shocknet


### PR DESCRIPTION
## Summary

Adds a current Umbrel reference package under `Umbrel/` for Lightning.Pub.

### What this package does
- Uses image `ghcr.io/shocknet/lightning-pub:0.0.40` (linux/amd64 and linux/arm64)
- Requires the Umbrel Lightning Node app (LND) and mounts its cert/macaroon
- Stores Pub data under `/data`
- Turns on the wizard UI (`WIZARD=true`) and fronts port `1777` through Umbrel `app_proxy`
- Sets `WATCHDOG_MAX_DIFF_SATS=100000000` (1 BTC). Pub's default is `0`, which blocks outbound payments if LND's balance differs from Pub's internal books at all. On Umbrel, other apps can also spend from the same LND, so a non-zero limit is required for normal shared use.

### Still needed before an Umbrel App Store submission
- Prebuild TypeScript in the Docker image, then run as `user: 1000:1000`
- Install and test on Umbrel: wizard loads, ShockWallet connects, data survives restart
- Open the follow-up PR against `getumbrel/umbrel-apps`

## Test plan
- [ ] Install this package on Umbrel with Lightning Node unlocked
- [ ] Confirm the wizard opens in the browser
- [ ] Confirm ShockWallet can connect with the admin string
- [ ] Confirm Pub data is still present after a container restart
