### PR TITLE
Don't treat a missing provider snapshot as a 0-sat rug

### DIFF
--- a/src/services/main/liquidityProvider.ts
+++ b/src/services/main/liquidityProvider.ts
@@ -32,6 +32,8 @@ export class LiquidityProvider {
     feesCache: Types.CumulativeFees | null = null
     lastSeenBeacon = 0
     latestReceivedBalance = 0
+    balanceKnown = false
+    balanceSnapshotInFlight = false
     incrementProviderBalance: (balance: number, tx?: string) => Promise<void>
     pendingPaymentsAck: Record<string, boolean> = {}
     // make the sub process accept client
@@ -129,8 +131,12 @@ export class LiquidityProvider {
         if (res.status === 'ERROR' && res.reason !== 'timeout') {
             return
         }
-        this.log("provider ready with balance:", res.status === 'OK' ? res.balance : 0)
-        this.lastSeenBeacon = Date.now()
+        if (res.status === 'OK') {
+            this.log("provider ready with balance:", res.balance)
+            this.lastSeenBeacon = Date.now()
+        } else {
+            this.log("provider GetUserInfo timed out, will not treat balance as 0 until a snapshot succeeds")
+        }
         this.ready = true
         this.queue.forEach(q => q('ready'))
         this.log("subbing to user operations")
@@ -144,7 +150,7 @@ export class LiquidityProvider {
                 try {
                     await this.invoicePaidCb(res.operation.identifier, res.operation.amount, 'provider')
                     this.incrementProviderBalance(res.operation.amount)
-                    this.latestReceivedBalance = res.latest_balance
+                    this.applyReceivedBalance(res.latest_balance)
                 } catch (err: any) {
                     this.log("error processing incoming invoice", err.message)
                 }
@@ -173,10 +179,31 @@ export class LiquidityProvider {
             serviceFeeFloor: res.network_max_fee_fixed,
             serviceFeeBps: res.service_fee_bps
         }
-        this.latestReceivedBalance = res.balance
+        this.applyReceivedBalance(res.balance)
         this.utils.stateBundler.AddBalancePoint('providerBalance', res.balance)
         this.utils.stateBundler.AddBalancePoint('providerMaxWithdrawable', res.max_withdrawable)
         return res
+    }
+
+    HasKnownBalance = () => {
+        return this.balanceKnown
+    }
+
+    applyReceivedBalance = (balance: number) => {
+        this.latestReceivedBalance = balance
+        this.balanceKnown = true
+    }
+
+    refreshBalanceIfUnknown = async () => {
+        if (this.balanceKnown || this.balanceSnapshotInFlight) {
+            return
+        }
+        this.balanceSnapshotInFlight = true
+        try {
+            await this.GetUserState()
+        } finally {
+            this.balanceSnapshotInFlight = false
+        }
     }
 
     GetFees = () => {
@@ -328,7 +355,7 @@ export class LiquidityProvider {
             if (from === 'system') {
                 await this.SettleProviderPayment(invoice, totalPaid)
             }
-            this.latestReceivedBalance = res.latest_balance
+            this.applyReceivedBalance(res.latest_balance)
             this.utils.stateBundler.AddTxPoint('paidAnInvoice', decodedAmount, { used: 'provider', from, timeDiscount: true })
             return res
         } catch (err) {
@@ -412,6 +439,9 @@ export class LiquidityProvider {
         this.lastSeenBeacon = Date.now()
         if (beacon.fees) {
             this.feesCache = beacon.fees
+        }
+        if (!this.balanceKnown) {
+            void this.refreshBalanceIfUnknown()
         }
     }
 

--- a/src/services/main/rugPullTracker.ts
+++ b/src/services/main/rugPullTracker.ts
@@ -25,20 +25,28 @@ export class RugPullTracker {
             return { balance: 0 }
         }
         const providerTracker = await this.storage.liquidityStorage.GetTrackedProvider('lnPub', pubDst)
-        const ready = this.liquidProvider.IsReady()
-        if (ready) {
-            const balance = this.liquidProvider.GetLatestBalance()
-            const pendingBalance = await this.liquidProvider.GetPendingBalance()
-            const trackedBalance = balance + pendingBalance
-            if (!providerTracker) {
-                this.log("starting to track provider", this.liquidProvider.GetProviderPubkey())
-                await this.storage.liquidityStorage.CreateTrackedProvider('lnPub', pubDst, trackedBalance)
-                return { balance: trackedBalance }
-            }
-            return this.checkForDisruption(pubDst, trackedBalance, providerTracker)
-        } else {
+        if (!this.liquidProvider.IsReady()) {
             return { balance: providerTracker?.latest_balance || 0 }
         }
+        if (!await this.ensureKnownBalance()) {
+            this.log("provider balance snapshot unavailable, skipping disruption check")
+            return { balance: providerTracker?.latest_balance || 0 }
+        }
+        const trackedBalance = this.liquidProvider.GetLatestBalance() + await this.liquidProvider.GetPendingBalance()
+        if (!providerTracker) {
+            this.log("starting to track provider", this.liquidProvider.GetProviderPubkey())
+            await this.storage.liquidityStorage.CreateTrackedProvider('lnPub', pubDst, trackedBalance)
+            return { balance: trackedBalance }
+        }
+        return this.checkForDisruption(pubDst, trackedBalance, providerTracker)
+    }
+
+    ensureKnownBalance = async () => {
+        if (this.liquidProvider.HasKnownBalance()) {
+            return true
+        }
+        await this.liquidProvider.refreshBalanceIfUnknown()
+        return this.liquidProvider.HasKnownBalance()
     }
 
     checkForDisruption = async (pubDst: string, trackedBalance: number, providerTracker: TrackedProvider) => {

--- a/src/tests/rugPullTracker.spec.ts
+++ b/src/tests/rugPullTracker.spec.ts
@@ -1,0 +1,133 @@
+import { LiquidityProvider } from "../services/main/liquidityProvider.js"
+import { RugPullTracker } from "../services/main/rugPullTracker.js"
+import { Utils } from "../services/helpers/utilsWrapper.js"
+import { NostrSender } from "../services/nostr/sender.js"
+import { StorageTestBase } from "./testBase.js"
+
+export const ignore = false
+export const dev = false
+export const requires = "storage" as const
+
+type StubState = {
+    ready: boolean
+    known: boolean
+    latest: number
+    pending: number
+}
+
+type Harness = {
+    T: StorageTestBase
+    utils: Utils
+    lp: LiquidityProvider
+}
+
+const peerPub = (n: number) => n.toString(16).padStart(64, "c")
+
+const setupHarness = (T: StorageTestBase): Harness => {
+    const pub = peerPub(Date.now())
+    const utils = new Utils({
+        dataDir: T.storage.getStorageSettings().dataDir,
+        allowResetMetricsStorages: true,
+        noCollector: true,
+    }, new NostrSender())
+    const lp = new LiquidityProvider(
+        () => ({
+            liquidityProviderPub: pub,
+            disableLiquidityProvider: false,
+            useOnlyLiquidityProvider: false,
+            providerRelayUrl: "",
+        }),
+        utils,
+        async () => { },
+        async () => { },
+    )
+    return { T, utils, lp }
+}
+
+const newTracker = (h: Harness) => new RugPullTracker(h.T.storage, h.lp)
+
+const stubProvider = (lp: LiquidityProvider, pub: string, state: StubState) => {
+    lp.GetProviderPubkey = () => pub
+    lp.IsReady = () => state.ready
+    lp.HasKnownBalance = () => state.known
+    lp.GetLatestBalance = () => state.latest
+    lp.GetPendingBalance = async () => state.pending
+    lp.refreshBalanceIfUnknown = async () => { }
+}
+
+const seedTrackedBalance = async (h: Harness, pub: string, latestBalance: number) => {
+    await h.T.storage.liquidityStorage.CreateTrackedProvider("lnPub", pub, latestBalance)
+}
+
+export default async (T: StorageTestBase) => {
+    const h = setupHarness(T)
+    try {
+        await testUnknownZeroDoesNotRug(h)
+        await testKnownZeroDoesRug(h)
+        await testRetrySnapshotMatchingBalanceDoesNotRug(h)
+        await testKnownMatchingBalanceDoesNotRug(h)
+    } finally {
+        h.utils.Stop()
+    }
+}
+
+const testUnknownZeroDoesNotRug = async (h: Harness) => {
+    h.T.d("starting testUnknownZeroDoesNotRug")
+    const pub = peerPub(Date.now() + 1)
+    await seedTrackedBalance(h, pub, 10145)
+    stubProvider(h.lp, pub, { ready: true, known: false, latest: 0, pending: 0 })
+    const tracker = newTracker(h)
+    const res = await tracker.CheckProviderBalance()
+    h.T.expect(res.balance).to.equal(10145)
+    h.T.expect(tracker.HasProviderRugPulled()).to.equal(false)
+    const stored = await h.T.storage.liquidityStorage.GetTrackedProvider("lnPub", pub)
+    h.T.expect(stored?.latest_distruption_at_unix).to.equal(0)
+    h.T.d("unknown provider snapshot is not treated as a 0-sat rug")
+}
+
+const testKnownZeroDoesRug = async (h: Harness) => {
+    h.T.d("starting testKnownZeroDoesRug")
+    const pub = peerPub(Date.now() + 2)
+    await seedTrackedBalance(h, pub, 10145)
+    stubProvider(h.lp, pub, { ready: true, known: true, latest: 0, pending: 0 })
+    const tracker = newTracker(h)
+    const first = await tracker.CheckProviderBalance()
+    h.T.expect(first.balance).to.equal(0)
+    h.T.expect(first.prevBalance).to.equal(10145)
+    h.T.expect(tracker.HasProviderRugPulled()).to.equal(true)
+    const afterDetect = await h.T.storage.liquidityStorage.GetTrackedProvider("lnPub", pub)
+    h.T.expect(afterDetect && afterDetect.latest_distruption_at_unix > 0).to.equal(true)
+    const second = await tracker.CheckProviderBalance()
+    h.T.expect(second.balance).to.equal(0)
+    h.T.expect(tracker.HasProviderRugPulled()).to.equal(true)
+    h.T.d("confirmed 0-sat snapshot against 10145 is a rug, including ongoing")
+}
+
+const testRetrySnapshotMatchingBalanceDoesNotRug = async (h: Harness) => {
+    h.T.d("starting testRetrySnapshotMatchingBalanceDoesNotRug")
+    const pub = peerPub(Date.now() + 3)
+    await seedTrackedBalance(h, pub, 10145)
+    const state: StubState = { ready: true, known: false, latest: 0, pending: 0 }
+    stubProvider(h.lp, pub, state)
+    h.lp.refreshBalanceIfUnknown = async () => {
+        state.known = true
+        state.latest = 10145
+    }
+    const tracker = newTracker(h)
+    const res = await tracker.CheckProviderBalance()
+    h.T.expect(res.balance).to.equal(10145)
+    h.T.expect(tracker.HasProviderRugPulled()).to.equal(false)
+    h.T.d("watchdog retry that fills in the real snapshot does not rug")
+}
+
+const testKnownMatchingBalanceDoesNotRug = async (h: Harness) => {
+    h.T.d("starting testKnownMatchingBalanceDoesNotRug")
+    const pub = peerPub(Date.now() + 4)
+    await seedTrackedBalance(h, pub, 10145)
+    stubProvider(h.lp, pub, { ready: true, known: true, latest: 10145, pending: 0 })
+    const tracker = newTracker(h)
+    const res = await tracker.CheckProviderBalance()
+    h.T.expect(res.balance).to.equal(10145)
+    h.T.expect(tracker.HasProviderRugPulled()).to.equal(false)
+    h.T.d("matching confirmed snapshot does not rug")
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Connect was marking the liquidity provider ready with balance 0 after `GetUserInfo` timed out. The watchdog then compared that 0 to the last tracked balance every minute and logged an ongoing rugpull.

That matches the reported loop after restart (`10145 → 0`, one line per minute). Timeouts make the snapshot never arrive; the tracker never updates stored `latest_balance` on a drop, so it keeps logging `ongoing`.

## Fix
- Remember whether a provider balance snapshot was actually received this process.
- On `GetUserInfo` timeout, do not treat balance as 0 or fake a last-seen beacon.
- Skip the disruption check until a snapshot succeeds; retry on watchdog ticks and provider beacons.
- A confirmed 0 against a stored positive balance still flags a rug.

This is a consumer-side false positive. It does not prove the provider actually zeroed the account.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `rugPullTracker.spec.ts` (storage) — 4 pass: unknown 0 does not rug; confirmed 0 vs 10145 detects then logs ongoing; retry snapshot matching 10145 does not rug; matching snapshot does not rug

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9668a1df-5ace-4a74-989b-fb5e255a3433?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9668a1df-5ace-4a74-989b-fb5e255a3433&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

